### PR TITLE
[DNM] [ENG-9748] Tighten PHP constraint to ^8.5; tighten guzzle to ^7.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
       - name: Validate composer.json and composer.lock
         run: composer validate
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"require": {
 		"php": "^8.5",
 		"ext-json": "*",
-		"guzzlehttp/guzzle": "^7.5"
+		"guzzlehttp/guzzle": "^7.10"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "~1",

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
 	"name": "insites/insites-sdk-php",
 	"description": "PHP client for integrating Insites into your projects.",
 	"require": {
-		"php": "^7.4|^8",
+		"php": "^8.5",
 		"ext-json": "*",
-		"guzzlehttp/guzzle": "~6.0|~7.0"
+		"guzzlehttp/guzzle": "^7.5"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "~1",

--- a/src/Http/HttpWrapper.php
+++ b/src/Http/HttpWrapper.php
@@ -17,7 +17,7 @@ class HttpWrapper
     private ?string $locale;
     private GuzzleClient $guzzle;
 
-    public function __construct(string $apiKey, ?string $locale, GuzzleClient $guzzle = null, string $host = null)
+    public function __construct(string $apiKey, ?string $locale, ?GuzzleClient $guzzle = null, ?string $host = null)
     {
         $this->apiKey = $apiKey;
         $this->locale = $locale;


### PR DESCRIPTION
## Summary
- Tighten `php` constraint from `^7.4|^8` to `^8.5`
- Tighten `guzzlehttp/guzzle` from `~6.0|~7.0` to `^7.5` (Guzzle 6 has no PHP 8.5 support; consumers already use Guzzle 7)
- Fix implicit-nullable params on `HttpWrapper::__construct` (PHP 8.4+ explicit-nullable rule)
- Add `shivammathur/setup-php@v2` step pinning CI to PHP 8.5 (previously had no PHP version pin)

## Pre-release tagged
**`2.1.0` is tagged on this branch HEAD as a GitHub pre-release**: https://github.com/insites/insites-sdk-php/releases/tag/2.1.0

`runway`, `hawkeye`, and `vulcan` can test against this tag (or the branch SHA) before this PR merges. **Note**: composer treats `2.1.0` as stable regardless of the GitHub pre-release flag — `^2.0` constraints will pick it up automatically on `composer update`.

## Source change (1 file, 2 params)
`src/Http/HttpWrapper.php:20` — `__construct(..., GuzzleClient $guzzle = null, string $host = null)` → `?GuzzleClient $guzzle = null, ?string $host = null` (BC-safe — semantically identical signatures).

No Rector was run; only 1 implicit-nullable hotspot existed, no PHPUnit deprecations to address (no test suite), and no other PHP 8.5 issues found (no case-label-semicolons, no `str_getcsv`, no untyped properties).

## Verification
- `composer validate` — valid (pre-existing "no license" warning unchanged)
- `composer audit` — no security advisories
- `composer update` — clean resolution; Guzzle 7.10.5 installed
- `vendor/bin/phpstan analyse -l 5 src` — **[OK] No errors** on PHP 8.5

## Public API preserved
3 consumers (runway, hawkeye, vulcan) — `HttpWrapper::__construct` signature change is BC-safe (implicit-nullable → explicit-nullable is semantically identical for callers).

## Out of scope
- Adding a test suite (none exists today; that's a separate initiative)
- PHPStan 2.x upgrade (PHPStan emits a marketing prompt asking to upgrade; out of scope here)

## Consumer follow-up (3 repos, separate PRs)
- runway
- hawkeye
- vulcan

## Test plan
- [x] `composer validate` — valid
- [x] `composer audit` — no security advisories
- [x] `vendor/bin/phpstan analyse -l 5 src` — clean on PHP 8.5
- [x] `2.1.0` tagged as GitHub pre-release on branch HEAD
- [ ] CI green on PHP 8.5
- [ ] runway / hawkeye / vulcan test against 2.1.0 / branch SHA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP requirement to 8.5.
  * Updated Guzzle HTTP dependency to 7.10.
  * CI checks now explicitly run with PHP 8.5 to align validation and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insites/insites-sdk-php/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->